### PR TITLE
Fix #1: filter out Core set cards that cannot be crafted with dust

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -31,6 +31,8 @@ function getCardData() {
 		var match = bg.match(/url\(["']?([^"')]+)["']?\)/);
 		var cardId = match ? match[1].split('/').pop().replace(/\.\w+$/, '') : null;
 		var imgUrl = cardId ? 'https://art.hearthstonejson.com/v1/render/latest/enUS/256x/' + cardId + '.png' : null;
+		// Skip Core set cards — they cannot be crafted with dust
+		if (cardId && cardId.startsWith('CORE_')) return;
 		if (name && imgUrl) {
 			names.push(name);
 			images.push(imgUrl);


### PR DESCRIPTION
Core set cards have IDs prefixed with CORE_ and are automatically granted
to players — they cannot be crafted or disenchanted. Skip them in getCardData()
so the extension only recommends cards the user can actually craft.

https://claude.ai/code/session_01KLxr9YQQ3qThcfoVR9QuVX