### PR TITLE
Add async card fetching and filter uncraftable cards via API

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -19,7 +19,7 @@
   <!-- Error state -->
   <div id="error-state" style="display:none">
     <div class="wc-card-border fantasy" id="error-frame">
-      Visit HSReplay.net/decks to find your best craft!
+      <p id="error-message">Visit HSReplay.net/decks to find your best craft!</p>
     </div>
   </div>
 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,27 +1,56 @@
 console.log('Content script running...');
 
+// Sets whose cards cannot be crafted with dust
+var UNCRAFTABLE_SETS = ['CORE', 'PATH_OF_ARTHAS', 'ISLAND_VACATION'];
+
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	if (request.type === 'getBestCard') {
-		sendResponse({ card: findBestCraft() });
+		findBestCraft().then(function(result) {
+			sendResponse({ card: result });
+		}).catch(function() {
+			sendResponse({ card: null });
+		});
+		return true; // Keep message channel open for async response
 	}
 });
 
 function findBestCraft() {
-	var allCraftableCardData = getCardData();
-	var allCraftableCards = trimMultiplierText(allCraftableCardData[0], allCraftableCardData[1], allCraftableCardData[2]);
-	var bestValueCraftCard = mostFrequentOccuranceIn(allCraftableCards[0]);
-	var bestCardIndex = allCraftableCards[0].indexOf(bestValueCraftCard[0]);
-	var result = {
-		name: bestValueCraftCard[0],
-		imageUrl: allCraftableCards[1][bestCardIndex],
-		cardId: allCraftableCards[2][bestCardIndex],
-		frequency: bestValueCraftCard[1]
-	};
-	console.log('bestValueCraft:', result);
-	return result;
+	return fetchUncraftableIds().then(function(uncraftableIds) {
+		var allCraftableCardData = getCardData(uncraftableIds);
+		var allCraftableCards = trimMultiplierText(allCraftableCardData[0], allCraftableCardData[1], allCraftableCardData[2]);
+		var bestValueCraftCard = mostFrequentOccuranceIn(allCraftableCards[0]);
+		var bestCardIndex = allCraftableCards[0].indexOf(bestValueCraftCard[0]);
+		var result = {
+			name: bestValueCraftCard[0],
+			imageUrl: allCraftableCards[1][bestCardIndex],
+			cardId: allCraftableCards[2][bestCardIndex],
+			frequency: bestValueCraftCard[1]
+		};
+		console.log('bestValueCraft:', result);
+		return result;
+	});
 }
 
-function getCardData() {
+function fetchUncraftableIds() {
+	return fetch('https://api.hearthstonejson.com/v1/latest/enUS/cards.collectible.json')
+		.then(function(res) { return res.json(); })
+		.then(function(cards) {
+			var ids = new Set();
+			cards.forEach(function(card) {
+				if (UNCRAFTABLE_SETS.indexOf(card.set) !== -1) {
+					ids.add(card.id);
+				}
+			});
+			console.log('Uncraftable card IDs loaded:', ids.size);
+			return ids;
+		})
+		.catch(function(e) {
+			console.log('Could not fetch card data, falling back to CORE_ prefix filter only:', e);
+			return new Set();
+		});
+}
+
+function getCardData(uncraftableIds) {
 	var names = [];
 	var images = [];
 	var cardIds = [];
@@ -33,6 +62,8 @@ function getCardData() {
 		var imgUrl = cardId ? 'https://art.hearthstonejson.com/v1/render/latest/enUS/256x/' + cardId + '.png' : null;
 		// Skip Core set cards — they cannot be crafted with dust
 		if (cardId && cardId.startsWith('CORE_')) return;
+		// Skip other uncraftable cards identified via HearthstoneJSON set data
+		if (cardId && uncraftableIds.has(cardId)) return;
 		if (name && imgUrl) {
 			names.push(name);
 			images.push(imgUrl);

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,8 +1,5 @@
 console.log('Content script running...');
 
-// Sets whose cards cannot be crafted with dust
-var UNCRAFTABLE_SETS = ['CORE', 'PATH_OF_ARTHAS', 'ISLAND_VACATION'];
-
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	if (request.type === 'getBestCard') {
 		findBestCraft().then(function(result) {
@@ -37,7 +34,8 @@ function fetchUncraftableIds() {
 		.then(function(cards) {
 			var ids = new Set();
 			cards.forEach(function(card) {
-				if (UNCRAFTABLE_SETS.indexOf(card.set) !== -1) {
+				// FREE rarity = no rarity gem = cannot be crafted with dust (Core Set, Path of Arthas, etc.)
+				if (!card.rarity || card.rarity === 'FREE') {
 					ids.add(card.id);
 				}
 			});

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -38,9 +38,12 @@ var SET_NAMES = {
   BATTLE_OF_THE_BANDS: 'Battle of the Bands',
 };
 
-function showError() {
+function showError(message) {
   document.getElementById('loading-state').style.display = 'none';
   document.getElementById('error-state').style.display = 'block';
+  if (message) {
+    document.getElementById('error-message').textContent = message;
+  }
 }
 
 function stripHtml(html) {
@@ -139,8 +142,12 @@ function renderCard(card, frequency) {
 
 chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
   chrome.tabs.sendMessage(tabs[0].id, { type: 'getBestCard' }, function(response) {
-    if (chrome.runtime.lastError || !response || !response.card || !response.card.name) {
+    if (chrome.runtime.lastError || !response) {
       showError();
+      return;
+    }
+    if (!response.card || !response.card.name) {
+      showError('No craftable cards found. Try the Missing Cards tab on HSReplay.net/decks.');
       return;
     }
 

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -147,7 +147,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
       return;
     }
     if (!response.card || !response.card.name) {
-      showError('No craftable cards found. Try the Missing Cards tab on HSReplay.net/decks.');
+      showError('No craftable cards found. Sync your collection via HDT and browse decks on HSReplay.net/decks.');
       return;
     }
 


### PR DESCRIPTION
## Summary
This PR refactors the card crafting recommendation system to use asynchronous operations and implements a more comprehensive filter for uncraftable cards by integrating with the HearthstoneJSON API.

## Key Changes
- **Async message handling**: Modified the `getBestCard` message listener to properly handle asynchronous operations by returning `true` and using promise-based responses instead of synchronous calls
- **New uncraftable card filtering**: Added `fetchUncraftableIds()` function that fetches card data from HearthstoneJSON API to identify cards with FREE rarity or no rarity (which cannot be crafted with dust)
- **Enhanced card filtering**: Updated `getCardData()` to accept an `uncraftableIds` parameter and filter out both CORE set cards and other uncraftable cards identified via the API
- **Improved error handling**: Enhanced error messages in the popup to display specific reasons when no craftable cards are found, with fallback behavior if the API is unavailable
- **Better UX feedback**: Modified `showError()` to accept an optional message parameter and updated the error state HTML to dynamically display error messages

## Implementation Details
- The `fetchUncraftableIds()` function gracefully handles API failures by returning an empty Set, allowing the extension to fall back to the existing CORE_ prefix filter
- Promise chains are used throughout to maintain proper async flow from the content script through to the popup UI
- The HearthstoneJSON API call filters for collectible cards and identifies uncraftable cards by checking for missing or FREE rarity values

https://claude.ai/code/session_01EBmCWG3kL5S135EHGWtY7v